### PR TITLE
Update fs2 dependencies to 2.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ lazy val core = project
   .settings(name := "fs2-gzip")
   .settings(
      libraryDependencies ++= Seq(
-      "co.fs2"     %% "fs2-core"    % "1.0.0",
-      "co.fs2"     %% "fs2-io"      % "1.0.0" % "test",
+      "co.fs2"     %% "fs2-core"    % "2.2.2",
+      "co.fs2"     %% "fs2-io"      % "2.2.2" % "test",
       "org.specs2" %% "specs2-core" % "4.3.4" % "test"),
 
      addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"))


### PR DESCRIPTION
Hi,

I'd like to use it in one of my projects, but the `decompress` is not binary compatible anymore.
As the title says, this will update the library to the current stable version of `fs2-core` and `fs2-io` (2.2.2). 

I hope this isn't too much of a jump 🙂

Cheers
~ Felix